### PR TITLE
Moving to BrowserHistory

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux'
 import thunk from 'redux-thunk'
 import { checkIfAuthed } from 'helpers/authenticator'
 import { routerReducer, syncHistoryWithStore } from 'react-router-redux'
-import { hashHistory } from 'react-router'
+import { browserHistory } from 'react-router'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 
@@ -22,7 +22,7 @@ const store = createStore(
   )
 )
 
-const history = syncHistoryWithStore(hashHistory, store)
+const history = syncHistoryWithStore(browserHistory, store)
 
 function checkAuth (nextState, replace) {
   const isAuthed = checkIfAuthed(store)

--- a/server/server.js
+++ b/server/server.js
@@ -6,11 +6,11 @@ const __TEST__ = process.env.NODE_ENV === 'test'
 const PORT = process.env.PORT || 3000
 
 const app = express()
-const router = express.Router()
 
 if (__PROD__ || __TEST__) {
   const config = require('../tools/webpack.client.prod.babel').default
   app.use(config.output.publicPath, express.static(config.output.path))
+  app.get('*', (req, res) => res.sendFile(config.output.path + '/index.html'))
 } else {
   const webpack = require('webpack')
   const webpackDevMiddleware = require('webpack-dev-middleware')
@@ -18,17 +18,22 @@ if (__PROD__ || __TEST__) {
   const config = require('../tools/webpack.client.dev.babel').default
 
   const compiler = webpack(config)
-  const webpackMiddleware = webpackDevMiddleware(compiler, { quiet: true })
-  app.use(webpackMiddleware)
+
+  // https://github.com/webpack/webpack-dev-middleware
+  app.use(webpackDevMiddleware(compiler, {
+    publicPath: config.output.publicPath,
+    noInfo: true,
+  }))
+
+  // https://github.com/glenjamin/webpack-hot-middleware
   app.use(webpackHotMiddleware(compiler, {
     log: console.warn,
     publicPath: config.output.publicPath,
     stats: {colors: true},
   }))
-}
 
-app.use(router)
-app.use(express.static('public'))
+  app.get('*', (req, res) => res.sendFile(config.output.path + '/index.html'))
+}
 
 const server = app.listen(PORT, () => console.info('listening on port: ' + PORT))
 socketio(server)

--- a/tools/webpack.base.babel.js
+++ b/tools/webpack.base.babel.js
@@ -6,7 +6,7 @@ export default {
   CLIENT_OUTPUT: path.join(process.cwd(), 'public/generated-assets'),
   SERVER_ENTRY: path.join(process.cwd(), 'server/server.js'),
   SERVER_OUTPUT: path.join(process.cwd(), 'build'),
-  PUBLIC_PATH: '/',
+  PUBLIC_PATH: '/assets',
   HTML_WEBPACK_PLUGIN: new HtmlWebpackPlugin({
     template: path.join(process.cwd(), 'client', 'index.html'),
     filename: 'index.html',


### PR DESCRIPTION
- (client) using BrowserHistory in react
- (server) now all non-asset routes serve index.html
- (server) web pack public path is not /asset
